### PR TITLE
feat(ProfileSettings): Make filter textarea fill available height

### DIFF
--- a/app/components/settings/profiles/settings-profiles.component.tsx
+++ b/app/components/settings/profiles/settings-profiles.component.tsx
@@ -32,14 +32,25 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     flex: 1,
+    height: '100%',
   },
   height: {
     height: '100%',
+    flexGrow: 1,
+    display: 'flex',
+    flexDirection: 'column',
   },
   textarea: {
     maxHeight: 'unset',
     height: '100%',
     minHeight: '200px',
+    flexGrow: 1,
+  },
+  textareaField: {
+    flexGrow: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    paddingBottom: '20px'
   },
   gap: { display: 'flex', gap: '1rem' },
   bottom: { marginTop: 'auto' },
@@ -202,6 +213,7 @@ export default function ProfileSettings() {
           label={'Filter'}
           validationState="error"
           validationMessage={'Danger zone: Make sure you know what you are doing. This is a JSON object.'}
+          className={styles.textareaField}
         >
           <Textarea
             className={styles.height}


### PR DESCRIPTION
This pull request makes several improvements to the layout and styling of the profile settings component, focusing on better use of flexbox for consistent sizing and spacing. The main changes involve updating style definitions and applying them to the relevant components to ensure the textarea and its container expand and align properly.

**Styling and Layout Improvements:**

* Updated the `root`, `height`, and `textarea` style classes in `settings-profiles.component.tsx` to use flexbox properties and ensure elements expand to fill available space.
* Added a new `textareaField` style class to provide additional flexbox layout and padding for the textarea's container.
* Applied the new `textareaField` style class to the container of the textarea in the `ProfileSettings` component to improve layout consistency.