### PR TITLE
Handle overflow for horizontal PR tabs

### DIFF
--- a/app/pages/pull-requests/pull-requests.tsx
+++ b/app/pages/pull-requests/pull-requests.tsx
@@ -219,7 +219,7 @@ export default function PullRequestsOverview() {
 
       const tab: React.ReactNode = (
         <OverflowItem key={profile.id} id={profile.id}>
-          <Tab value={profile.id} onAuxClick={onProfileHeaderAuxClick}>
+          <Tab key={profile.id} value={profile.id} onAuxClick={onProfileHeaderAuxClick}>
             {profile.label} {badge}
           </Tab>
         </OverflowItem>

--- a/app/pages/pull-requests/pull-requests.tsx
+++ b/app/pages/pull-requests/pull-requests.tsx
@@ -219,7 +219,7 @@ export default function PullRequestsOverview() {
 
       const tab: React.ReactNode = (
         <OverflowItem key={profile.id} id={profile.id}>
-          <Tab key={profile.id} value={profile.id} onAuxClick={onProfileHeaderAuxClick}>
+          <Tab value={profile.id} onAuxClick={onProfileHeaderAuxClick}>
             {profile.label} {badge}
           </Tab>
         </OverflowItem>

--- a/app/pages/pull-requests/pull-requests.tsx
+++ b/app/pages/pull-requests/pull-requests.tsx
@@ -248,8 +248,8 @@ export default function PullRequestsOverview() {
             <Overflow minimumVisible={2}>
               <TabList selectedValue={selectedValue} onTabSelect={(_, d) => onTabSelect(d.value as string)}>
                 {details.map((detail) => detail.tab)}
-                <OverflowMenu profiles={details.map(x => x.profile)} onTabSelect={onTabSelect} />
               </TabList>
+              <OverflowMenu profiles={details.map(x => x.profile)} onTabSelect={onTabSelect} />
             </Overflow>
           </div>
           <div className="content scrollable-content">{details.map((detail) => detail.list)}</div>

--- a/app/pages/pull-requests/pull-requests.tsx
+++ b/app/pages/pull-requests/pull-requests.tsx
@@ -6,16 +6,15 @@ import { PrProfile } from '@/lib/models/pr-profile'
 import { PullRequest } from '@/lib/models/pull-request.model'
 import { FilterEvaluator } from '@/lib/models/ui-filter.model'
 import type {
+  MenuItemProps,
   MenuProps,
   PositioningImperativeRef,
   PositioningShorthand,
   PositioningVirtualElement,
-  SelectTabData,
-  SelectTabEvent,
-  TabValue,
+  TabValue
 } from '@fluentui/react-components'
-import { CounterBadge, Menu, MenuItem, MenuList, MenuPopover, Tab, TabList } from '@fluentui/react-components'
-import { ThumbLikeFilled } from '@fluentui/react-icons'
+import { Button, CounterBadge, makeStyles, Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, Overflow, OverflowItem, Tab, TabList, tokens, useIsOverflowItemVisible, useOverflowMenu } from '@fluentui/react-components'
+import { MoreHorizontalRegular, ThumbLikeFilled } from '@fluentui/react-icons'
 import { useEffect, useRef, useState } from 'react'
 import './pull-requests.scss'
 
@@ -46,6 +45,95 @@ function TabHeaderMenu({
     </Menu>
   )
 }
+
+/**
+ * Props for an overflow menu that displays when there are more tabs than available space
+ */
+type OverflowMenuProps = {
+  onTabSelect?: (tabId: string) => void;
+  profiles: PrProfile[];
+};
+
+/**
+ * Props for an overflow menu item that only displays when the tab is not visible
+ */
+type OverflowMenuItemProps = {
+  tab: PrProfile;
+
+  onClick: MenuItemProps["onClick"];
+};
+
+/**
+* A menu item for an overflow menu that only displays when the tab is not visible
+*/
+const OverflowMenuItem = (props: OverflowMenuItemProps) => {
+  const { tab, onClick } = props;
+  const isVisible = useIsOverflowItemVisible(tab.id);
+
+  if (isVisible) {
+    return null;
+  }
+
+  return (
+    <MenuItem key={tab.id} onClick={onClick}>
+      <div>{tab.label}</div>
+    </MenuItem>
+  );
+};
+
+/**
+ * Styles for the overflow menu
+ */
+const useOverflowMenuStyles = makeStyles({
+  menu: {
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
+  menuButton: {
+    alignSelf: "center",
+  },
+});
+
+const OverflowMenu = (props: OverflowMenuProps) => {
+  const { onTabSelect, profiles } = props;
+  const { ref, isOverflowing, overflowCount } =
+    useOverflowMenu<HTMLButtonElement>();
+
+  const styles = useOverflowMenuStyles();
+
+  const onItemClick = (tabId: string) => {
+    onTabSelect?.(tabId);
+  };
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <Menu hasIcons>
+      <MenuTrigger disableButtonEnhancement>
+        <Button
+          appearance="transparent"
+          className={styles.menuButton}
+          ref={ref}
+          icon={<MoreHorizontalRegular />}
+          aria-label={`${overflowCount} more tabs`}
+          role="tab"
+        />
+      </MenuTrigger>
+      <MenuPopover>
+        <MenuList className={styles.menu}>
+          {profiles.map((tab) => (
+            <OverflowMenuItem
+              key={tab.id}
+              tab={tab}
+              onClick={() => onItemClick(tab.id)}
+            />
+          ))}
+        </MenuList>
+      </MenuPopover>
+    </Menu>
+  );
+};
 
 export default function PullRequestsOverview() {
   const positioningRef = useRef<PositioningImperativeRef>(null)
@@ -86,9 +174,9 @@ export default function PullRequestsOverview() {
     return PullRequestErrors(pullRequests.error)
   }
 
-  const onTabSelect = (_e: SelectTabEvent, data: SelectTabData) => {
-    setSelectedValue(data.value)
-  }
+  const onTabSelect = (profileId: string) => {
+    setSelectedValue(profileId);
+  };
 
   const onHeaderAuxClick = (e: { target: (HTMLElement | PositioningVirtualElement) | null }) => {
     positioningRef.current?.setTarget(e.target)
@@ -108,20 +196,23 @@ export default function PullRequestsOverview() {
 
       const onProfileHeaderAuxClick = profile.enableAcceptAll
         ? (e) => {
-            setMenuData(filtered)
-            onHeaderAuxClick(e)
-          }
+          setMenuData(filtered)
+          onHeaderAuxClick(e)
+        }
         : undefined
 
       const tab: React.ReactNode = (
-        <Tab key={profile.id} value={profile.id} onAuxClick={onProfileHeaderAuxClick}>
-          {profile.label} {badge}
-        </Tab>
+        <OverflowItem key={profile.id} id={profile.id}>
+          <Tab key={profile.id} value={profile.id} onAuxClick={onProfileHeaderAuxClick}>
+            {profile.label} {badge}
+          </Tab>
+        </OverflowItem>
       )
 
       const list: React.ReactNode = selectedValue === profile.id && <PrList key={profile.id} data={filtered} />
 
       return {
+        profile,
         tab,
         list,
       }
@@ -138,9 +229,14 @@ export default function PullRequestsOverview() {
       <div className="container">
         <div className="section">
           <div className="content header">
-            <TabList selectedValue={selectedValue} onTabSelect={onTabSelect}>
-              {details.map((detail) => detail.tab)}
-            </TabList>
+            <Overflow minimumVisible={2}>
+              <TabList selectedValue={selectedValue} onTabSelect={(_, d) => onTabSelect(d.value as string)}>
+                {details.map((detail) => detail.tab)}
+                <OverflowMenu profiles={details.map(x => x.profile)} onTabSelect={onTabSelect} />
+              </TabList>
+            </Overflow>
+          </div>
+          <div className="content header">
           </div>
           <div className="content scrollable-content">{details.map((detail) => detail.list)}</div>
         </div>

--- a/app/pages/pull-requests/pull-requests.tsx
+++ b/app/pages/pull-requests/pull-requests.tsx
@@ -76,7 +76,7 @@ const OverflowMenuItem = (props: OverflowMenuItemProps) => {
 
   return (
     <MenuItem key={tab.id} onClick={onClick}>
-      <div>{tab.label}</div>
+      {tab.label}
     </MenuItem>
   );
 };

--- a/app/pages/pull-requests/pull-requests.tsx
+++ b/app/pages/pull-requests/pull-requests.tsx
@@ -91,7 +91,7 @@ const OverflowMenuItem = (props: OverflowMenuItemProps) => {
   }
 
   return (
-    <MenuItem key={tab.id} onClick={onClick}>
+    <MenuItem onClick={onClick}>
       {tab.label}
     </MenuItem>
   );

--- a/app/pages/pull-requests/pull-requests.tsx
+++ b/app/pages/pull-requests/pull-requests.tsx
@@ -236,8 +236,6 @@ export default function PullRequestsOverview() {
               </TabList>
             </Overflow>
           </div>
-          <div className="content header">
-          </div>
           <div className="content scrollable-content">{details.map((detail) => detail.list)}</div>
         </div>
       </div>

--- a/app/pages/pull-requests/pull-requests.tsx
+++ b/app/pages/pull-requests/pull-requests.tsx
@@ -109,7 +109,7 @@ const OverflowMenu = (props: OverflowMenuProps) => {
   }
 
   return (
-    <Menu hasIcons>
+    <Menu>
       <MenuTrigger disableButtonEnhancement>
         <Button
           appearance="transparent"

--- a/app/pages/pull-requests/pull-requests.tsx
+++ b/app/pages/pull-requests/pull-requests.tsx
@@ -248,8 +248,8 @@ export default function PullRequestsOverview() {
             <Overflow minimumVisible={2}>
               <TabList selectedValue={selectedValue} onTabSelect={(_, d) => onTabSelect(d.value as string)}>
                 {details.map((detail) => detail.tab)}
+                <OverflowMenu profiles={details.map(x => x.profile)} onTabSelect={onTabSelect} />
               </TabList>
-              <OverflowMenu profiles={details.map(x => x.profile)} onTabSelect={onTabSelect} />
             </Overflow>
           </div>
           <div className="content scrollable-content">{details.map((detail) => detail.list)}</div>

--- a/app/pages/pull-requests/pull-requests.tsx
+++ b/app/pages/pull-requests/pull-requests.tsx
@@ -13,7 +13,23 @@ import type {
   PositioningVirtualElement,
   TabValue
 } from '@fluentui/react-components'
-import { Button, CounterBadge, makeStyles, Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, Overflow, OverflowItem, Tab, TabList, tokens, useIsOverflowItemVisible, useOverflowMenu } from '@fluentui/react-components'
+import {
+  Button,
+  CounterBadge,
+  makeStyles,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  Overflow,
+  OverflowItem,
+  Tab,
+  TabList,
+  tokens,
+  useIsOverflowItemVisible,
+  useOverflowMenu,
+} from '@fluentui/react-components'
 import { MoreHorizontalRegular, ThumbLikeFilled } from '@fluentui/react-icons'
 import { useEffect, useRef, useState } from 'react'
 import './pull-requests.scss'


### PR DESCRIPTION
This pull request enhances the tab navigation experience in the pull requests overview page by introducing an overflow menu for tabs. When there are more tabs than can fit in the available space, excess tabs are now accessible via a "more" menu, improving usability and layout. The changes leverage Fluent UI's overflow utilities and update the tab selection logic accordingly.

**Tab overflow handling and UI improvements:**

* Added an `OverflowMenu` component and supporting types (`OverflowMenuProps`, `OverflowMenuItemProps`) to display hidden tabs in a dropdown when there are too many to fit, using Fluent UI's overflow hooks and components.
* Wrapped each tab in an `OverflowItem` and the `TabList` in an `Overflow` component to enable dynamic overflow detection and rendering. [[1]](diffhunk://#diff-8143468b1c79b3ed1f24395d8b54f08e350cd2c61b4cc0f4024aef5daabcb901R205-R215) [[2]](diffhunk://#diff-8143468b1c79b3ed1f24395d8b54f08e350cd2c61b4cc0f4024aef5daabcb901L141-R237)
* Updated imports to include Fluent UI overflow and button components, and added the "more" icon for the overflow menu.

**Tab selection logic:**

* Refactored the `onTabSelect` handler to work with the new overflow menu and tab selection approach, now using the profile ID directly.

![Aufzeichnung2025-11-06195448-ezgif com-optimize](https://github.com/user-attachments/assets/dd63f943-416d-47fe-a2ee-720d1ff0ec0f)
