### PR TITLE
refactor(ProfileSettings): remove minHeight from textarea style

### DIFF
--- a/app/components/settings/profiles/settings-profiles.component.tsx
+++ b/app/components/settings/profiles/settings-profiles.component.tsx
@@ -43,7 +43,6 @@ const useStyles = makeStyles({
   textarea: {
     maxHeight: 'unset',
     height: '100%',
-    minHeight: '200px',
     flexGrow: 1,
   },
   textareaField: {


### PR DESCRIPTION
This pull request makes a minor adjustment to the styles for the textarea in the `settings-profiles.component.tsx` file by removing the minimum height restriction. This allows the textarea to be more flexible in its sizing.

- Removed the `minHeight: '200px'` property from the `textarea` style in `settings-profiles.component.tsx`, allowing the textarea to shrink below 200px if needed.