### PR TITLE
fix default todo profile

### DIFF
--- a/lib/models/pr-profile.ts
+++ b/lib/models/pr-profile.ts
@@ -55,7 +55,7 @@ export const defaultProfiles: PrProfile[] = [
         {
           isDraft: false,
           author: {
-            op: "AND",
+            op: 'AND',
             filters: [
               {
                 isMySelf: false,

--- a/lib/models/pr-profile.ts
+++ b/lib/models/pr-profile.ts
@@ -53,6 +53,15 @@ export const defaultProfiles: PrProfile[] = [
       op: 'AND',
       filters: [
         {
+          isDraft: false,
+          author: {
+            op: "AND",
+            filters: [
+              {
+                isMySelf: false,
+              }
+            ]
+          },
           reviewers: {
             op: 'AND',
             filters: [


### PR DESCRIPTION
This pull request updates the default pull request profiles to further refine which pull requests are included. Specifically, it adds filters to exclude draft pull requests and those authored by the current user.

Filtering improvements to default PR profiles:

* Updated the `defaultProfiles` in `pr-profile.ts` to exclude draft pull requests (`isDraft: false`) and pull requests authored by the current user (`author.isMySelf: false`).

Fixes #159